### PR TITLE
feat: set linewidth as multiple of dpr with sensible default width

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -81,6 +81,9 @@ export function Line(props: LineProps) {
 
   onCleanup(() => lineGeometry().dispose())
 
+  const dpr = store.dpr ?? 1
+  const lineWidth = dpr * (config.linewidth ?? config.lineWidth ?? 1)
+  
   return (
     <>
       <T.Primitive object={line2()} ref={config.ref} {...rest}>
@@ -91,7 +94,7 @@ export function Line(props: LineProps) {
           color={config.color}
           vertexColors={Boolean(config.vertexColors)}
           resolution={[store.bounds.width, store.bounds.height]}
-          linewidth={config.linewidth ?? config.lineWidth}
+          linewidth={lineWidth}
           dashed={config.dashed}
           {...rest}
         />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Setting the linewidth as a multiple of dpr makes lines look right on all monitors

### What

<!-- what have you done, if its a bug, whats your solution? -->
Retrieved dpr from useThree context defaulting to 1 if undefined.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
